### PR TITLE
Use ASDF's SYSTEM-RELATIVE-PATHNAME to load main.ui

### DIFF
--- a/lispkit.asd
+++ b/lispkit.asd
@@ -16,4 +16,5 @@
                :purl
                :cl-xkeysym
                :lisp-unit
-               :split-sequence))
+               :split-sequence
+               :asdf))

--- a/lispkit.lisp
+++ b/lispkit.lisp
@@ -3,14 +3,15 @@
 (defun load-ui-from-file (path)
   (if (probe-file path)
       (let ((builder (gtk:gtk-builder-new)))
-        (gtk:gtk-builder-add-from-file builder path)
+        (gtk:gtk-builder-add-from-file builder (namestring path))
         builder)
       (error (format nil "non existent path: ~s" path))))
 
 (defun main (&rest args)
   (declare (ignore args))
   (within-main-loop
-    (let* ((ui     (load-ui-from-file "main.ui"))
+    (let* ((ui     (load-ui-from-file
+                    (asdf:system-relative-pathname :lispkit "main.ui")))
            (window (gtk:gtk-builder-get-object ui "mainwindow"))
            (frame  (gtk:gtk-builder-get-object ui "scrolledwindow"))
            (entry  (gtk:gtk-builder-get-object ui "entry_box"))


### PR DESCRIPTION
When loading lispkit after starting a basic SBCL REPL from a different directory it couldn't find the file, because it was looking in the wrong directory. When loading through SLIME this is apparently automatically taken care of.
