### PR TITLE
settings: adapt to cl-webkit

### DIFF
--- a/settings.lisp
+++ b/settings.lisp
@@ -1,5 +1,5 @@
 (in-package :lispkit)
 
 (defparameter *cookie-path-dir* (merge-pathnames  #P"lispkit/" (get-xdg-config-dir)))
-(defparameter *cookie-type* cl-webkit2:webkit-cookie-persistent-storage-text)
-(defparameter *cookie-accept-policy* cl-webkit2:webkit-cookie-policy-accept-always)
+(defparameter *cookie-type* cl-webkit2:+webkit-cookie-persistent-storage-text+)
+(defparameter *cookie-accept-policy* cl-webkit2:+webkit-cookie-policy-accept-always+)


### PR DESCRIPTION
Cookie option enum wrappers exported by cl-webkit
are now constants and have been renamed to follow the
+constant+ convention.
