### PR TITLE
Make lispkit work with current cl-webkit2 bindings

### DIFF
--- a/browser.lisp
+++ b/browser.lisp
@@ -80,7 +80,7 @@
 
 (defun make-webview ()
   (let* ((ctx (make-default-context))
-         (wv (cl-webkit2:webkit-web-view-new-with-context ctx)))
+         (wv (make-instance 'webkit2:webkit-web-view :context ctx)))
     wv))
 
 (defun make-default-context ()
@@ -152,9 +152,9 @@
 
 (defun apply-zoom (browser amount)
   (let* ((wv (webview browser))
-         (zoom-level (webkit2:webkit-web-view-get-zoom-level wv)))
+         (zoom-level (webkit2:webkit-web-view-zoom-level wv)))
     (print zoom-level)
-    (webkit2:webkit-web-view-set-zoom-level wv (+ zoom-level amount))))
+    (setf (webkit2:webkit-web-view-zoom-level wv) (+ zoom-level amount))))
 
 (defcommand zoom (browser)
   "Zoom the browser view in."

--- a/settings.lisp
+++ b/settings.lisp
@@ -1,5 +1,5 @@
 (in-package :lispkit)
 
 (defparameter *cookie-path-dir* (merge-pathnames  #P"lispkit/" (get-xdg-config-dir)))
-(defparameter *cookie-type* cl-webkit2:+webkit-cookie-persistent-storage-text+)
-(defparameter *cookie-accept-policy* cl-webkit2:+webkit-cookie-policy-accept-always+)
+(defparameter *cookie-type* :webkit-cookie-persistent-storage-text)
+(defparameter *cookie-accept-policy* :webkit-cookie-policy-accept-always)


### PR DESCRIPTION
Make Lispkit work with joachifm's current webkit2 bindings.
