### PR TITLE
Update the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ How to
 cd $QUICKLISP_HOME/local-projects
 git clone https://github.com/AeroNotix/cl-xkeysym.git
 git clone https://github.com/AeroNotix/lispkit.git
-git clone https://github.com/crategus/cl-cffi-gtk.git
 git clone https://github.com/joachifm/cl-webkit
 sbcl --noinform --quit --eval \
     "(ql:quickload :lispkit)"


### PR DESCRIPTION
cl-cffi-gtk has to be downloaded from quicklisp. The repo in the README is outdated.
