### PR TITLE
Makes the modeline start/stop able from lispkit

### DIFF
--- a/browser.lisp
+++ b/browser.lisp
@@ -69,7 +69,7 @@
                                  :tabs tabs
                                  :default-keymaps keymaps
                                  :keymaps keymaps)))
-    (start-modeloop browser)
+    (start-modeline browser)
     browser))
 
 (defun push-modeline (place thing browser)

--- a/lispkit.lisp
+++ b/lispkit.lisp
@@ -48,13 +48,13 @@
       (load-url *default-page* browser)
       (setf *default-browser* browser)
       (gtk-widget-hide entry)
-      (ensure-cookies-folder-exists *cookie-path-dir*)
-      ;; TODO - Add error handling to this.
-      (load-rc-file)
-      (gtk-window-maximize window)
       (gtk:gtk-container-add c-area lbl)
       (dolist (widget (list window frame view ib lbl))
-        (gtk-widget-show widget)))))
+        (gtk-widget-show widget))
+      (gtk-window-maximize window)
+      (ensure-cookies-folder-exists *cookie-path-dir*)
+      ;; TODO - Add error handling to this.
+      (load-rc-file))))
 
 (defun do-main (&rest args)
   "The main entry point when running as an executable. This should not

--- a/lispkit.lisp
+++ b/lispkit.lisp
@@ -43,7 +43,7 @@
         (g-signal-connect window "destroy"
                           (lambda (widget)
                             (declare (ignore widget))
-                            (stop-modeline)
+                            (stop-modeline browser)
                             (leave-gtk-main))))
       (load-url *default-page* browser)
       (setf *default-browser* browser)

--- a/modeline.lisp
+++ b/modeline.lisp
@@ -20,7 +20,9 @@
 (defun render-modeline (lbl modeline-state)
   (funcall *modeline-expander* lbl modeline-state))
 
-(defun start-modeloop (browser)
+(defcommand start-modeline (browser)
+  "Starts and displays the modeline"
+  (gtk:gtk-widget-show (get-widget browser "infobar1"))
   (let ((queue    (lparallel.queue:make-queue))
         (ml-state (make-hash-table :test #'equalp)))
     (push (bordeaux-threads:make-thread
@@ -35,6 +37,8 @@
           *modeline-workers*)
     (setf (modeline browser) queue)))
 
-(defun stop-modeline ()
+(defcommand stop-modeline (browser)
+  "Stops and destroys the modeline"
   (setf *modeline-quit* t)
+  (gtk:gtk-widget-hide (get-widget browser "infobar1"))
   (mapcar #'bordeaux-threads:join-thread *modeline-workers*))


### PR DESCRIPTION
For this, I had to change the `defun` to `defcommand`. Since `defcommand` unrolls to `defun`, everything keeps working together.

I also changed `start-modeloop` to `start-modeline`, as it made more sense.