### PR TITLE
Removes unneeded code for tests

### DIFF
--- a/test/test-suites.lisp
+++ b/test/test-suites.lisp
@@ -4,14 +4,6 @@
 (in-package #:lispkit-test)
 
 
-;; If the debugger is fired, it means something went wrong.
-(setf fiveam:*debug-on-error* t
-      fiveam:*debug-on-failure* t)
-(setf *debugger-hook*
-      (lambda (c h)
-	(declare (ignore c h))
-	(uiop:quit -1)))
-
 (5am:def-suite main)
 (5am:def-suite commands)
 (5am:def-suite events)


### PR DESCRIPTION
They actually hurt... if you run `(ql:quickload 'lispkit-test)`, it will
disable the debugger in your REPL.

And since tests are run with `run-tests.lisp`, that already does this, it can be safely removed.