### PR TITLE
Adds aergia targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ sbcl_TEST_OPTS=--noinform --disable-debugger --load $(QL_LOCAL)/setup.lisp --loa
 DISTRO_ID=$(shell source /etc/os-release && echo $$ID)
 
 
-.PHONY: deploy clean deb-package aur-package test printvars
+.PHONY: deploy clean deb-package aur-package test printvars aergia-create-container aergia-run
 
 all: $(APP_OUT)
 
@@ -113,3 +113,12 @@ $(APP_NAME)_debian.tar.gz: $(APP_OUT)
 
 printvars:
 	@$(foreach V,$(sort $(.VARIABLES)), $(if $(filter-out environment% default automatic, $(origin $V)),$(warning $V=$($V) ($(value $V)))))
+
+aergia-create-container:
+	@lxc-create --name lispkit \
+		--template ubuntu -- \
+		-S ~/.ssh/id_rsa.pub \
+		--packages make,sbcl,libglib2.0-0,libwebkit2gtk-3.0-dev,xvfb
+
+aergia-run:
+	@aergia --clone lispkit --username ubuntu --prefix common-lisp --command "xvfb-run make test"

--- a/Makefile
+++ b/Makefile
@@ -115,9 +115,12 @@ printvars:
 	@$(foreach V,$(sort $(.VARIABLES)), $(if $(filter-out environment% default automatic, $(origin $V)),$(warning $V=$($V) ($(value $V)))))
 
 aergia-create-container:
+ifndef SSHKEY
+	$(error SSHKEY needs to be provided. It must be the path to the public SSH key.)
+endif
 	@lxc-create --name lispkit \
 		--template ubuntu -- \
-		-S ~/.ssh/id_rsa.pub \
+		-S $(SSHKEY) \
 		--packages make,sbcl,libglib2.0-0,libwebkit2gtk-3.0-dev,xvfb
 
 aergia-run:


### PR DESCRIPTION
The `aergia-create-container` target only needs to be run once on the
machine.

The `aergia-run` target is the one to run every time tests need to be
run (in an isolated environment, ofc, ideally before pushing).

It is to be noted that I need to run these targets using sudo.

Of course, [aergia](https://github.com/Ralt/aergia) is needed to run these targets :-)