### PR TITLE
Fallback to a secondary protocol if primary (https) is not available

### DIFF
--- a/lispkit.asd
+++ b/lispkit.asd
@@ -27,5 +27,6 @@
                :parenscript
                :purl
                :split-sequence
-               :lparallel)
+               :lparallel
+               :usocket)
   :in-order-to ((test-op (test-op :lispkit-test))))

--- a/lispkit.asd
+++ b/lispkit.asd
@@ -28,5 +28,6 @@
                :purl
                :split-sequence
                :lparallel
+               :bordeaux-threads
                :usocket)
   :in-order-to ((test-op (test-op :lispkit-test))))


### PR DESCRIPTION
This should fix the issue with the browser always defaulting to https by dropping to http when the https version of a site (such as http://ahungry.com or http://ddg.gg) is not available.

However, I think there is an unrelated issue with webkit + Arch Linux, in that if the browser actually does drop to the fallback (by catching the #'handler-case error of usocket) it deadlocks.

Can someone on Ubuntu (or non Arch) test this commit and see if it works?

Expected behaviour is to be able to open just 'ahungry.com' and actually get the site vs a non-existing https://ahungry.com connection.